### PR TITLE
Fixed Handlebars helpers feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 node_modules
 test/_build
 npm-debug.log
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+*.iml
+.idea/

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function(settings) {
 
     try {
       helper = require(path.join(process.cwd(), helpers[i]));
-      Handlebars.registerPartial(name, helper);
+      Handlebars.registerHelper(name, helper);
     }
     catch (e) {
       console.warn('Error when loading ' + name + '.js as a Handlebars helper.');


### PR DESCRIPTION
Handlebars helpers was registered by calling  'registerPartial' instead of 'registerHelper'.

Changed index.js to call helpers with 'registerHelper', and added some JetBrains IDE specifics to .gitignore in the process.

> Screenshots of test/_build/index.html 

### Before:
![screen shot 2015-11-04 at 15 09 09](https://cloud.githubusercontent.com/assets/8521425/10941849/8841ce4a-830d-11e5-8462-3760ac0d44b9.png)

### After
![screen shot 2015-11-04 at 15 10 52](https://cloud.githubusercontent.com/assets/8521425/10941895/bb73ca52-830d-11e5-9496-34cde8b60104.png)


