### PR TITLE
Fixing data loading, data availability and partial loading

### DIFF
--- a/lib/loadData.js
+++ b/lib/loadData.js
@@ -23,6 +23,6 @@ module.exports = function(dir) {
       data = yaml.safeLoad(fs.readFileSync(dataFiles[i]));
     }
 
-    this.data = data;
+    this.data[name] = data;
   }
 }

--- a/lib/loadPartials.js
+++ b/lib/loadPartials.js
@@ -10,8 +10,9 @@ module.exports = function(dir) {
   var partials = glob.sync(path.join(dir, '**/*.{html,hbs,handlebars}'));
 
   for (var i in partials) {
+    var ext = path.extname(partials[i]);
     var file = fs.readFileSync(partials[i]);
-    var name = path.basename(partials[i], '.html');
+    var name = path.basename(partials[i], ext);
     this.Handlebars.registerPartial(name, file.toString() + '\n');
   }
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -32,7 +32,8 @@ module.exports = function(file, enc, cb) {
   pageData = page.attributes;
   pageData = extend(pageData, {
     page: path.basename(file.path, '.html'),
-    root: processRoot(file.path, this.options.root)
+    root: processRoot(file.path, this.options.root),
+    data: this.data
   });
 
   // Add special ad-hoc partials for #ifpage and #unlesspage


### PR DESCRIPTION
Adding 3 fixes in the pipeline:
- Partials can now be accessed using any of the file extensions `.{html,hbs,handlebars}`.
- Site-wide data from `data/` folder made available in templates.
- Fix overwriting of data objects when there are multiple data files.