### PR TITLE
dump helper from cache on reloading resolves #17

### DIFF
--- a/lib/loadHelpers.js
+++ b/lib/loadHelpers.js
@@ -14,11 +14,14 @@ module.exports = function(dir) {
     var name = path.basename(helpers[i], '.js');
 
     try {
+      if(this.Handlebars.helpers[name]){
+        delete require.cache[require.resolve(path.join(helpers[i]))];
+        this.Handlebars.unregisterHelper(name);
+      }
       helper = require(path.join(helpers[i]));
       this.Handlebars.registerHelper(name, helper);
     }
     catch (e) {
-      console.log(e);
       console.warn('Error when loading ' + name + '.js as a Handlebars helper.');
     }
   }


### PR DESCRIPTION
See #17

This allows helpers to be reloaded while panini is running.