### PR TITLE
Update render() - replace ._extend with deep merge; adjust order of merging data

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -1,4 +1,4 @@
-var extend = require('util')._extend;
+var extend = require('deepmerge');
 var fm = require('front-matter');
 var path = require('path');
 var through = require('through2');
@@ -19,7 +19,7 @@ function render(file, enc, cb) {
     // Get the HTML for the current page and layout
     var page = fm(file.contents.toString());
     var pageData;
-    
+
     // Get Layout
     var layout = page.attributes.layout || 'default';
     var layoutTemplate = this.layouts[layout];
@@ -32,18 +32,25 @@ function render(file, enc, cb) {
         throw new Error('Panini error: no layout named "'+layout+'" exists.');
       }
     }
-    
+
     // Now create Handlebars templates out of them
     var pageTemplate = this.Handlebars.compile(page.body + '\n');
 
-    // Next, extend the existing data object to include this page's metadata
-    pageData = page.attributes || {};
+    // Build page data with globals
+    pageData = extend({}, this.data);
+
+    // Add any data from stream plugins
+    pageData = (file.data) ? extend(pageData, file.data) : pageData;
+
+    // Add some defaults
     pageData = extend(pageData, {
       page: path.basename(file.path, '.html'),
       layout: layout,
       root: processRoot(file.path, this.options.root)
     });
-    pageData = extend(pageData, this.data);
+
+    // Finish by extending the existing data object with this page's metadata
+    pageData = extend(pageData, page.attributes);
 
     // Add special ad-hoc partials for #ifpage and #unlesspage
     this.Handlebars.registerHelper('ifpage', require('../helpers/ifPage')(pageData.page));
@@ -52,7 +59,7 @@ function render(file, enc, cb) {
     // Finally, add the page as a partial called "body", and render the layout template
     this.Handlebars.registerPartial('body', pageTemplate);
     file.contents = new Buffer(layoutTemplate(pageData));
-    
+
   }
   catch (e) {
     if (layoutTemplate) {
@@ -67,10 +74,10 @@ function render(file, enc, cb) {
     }
     // Log the error into console
     console.log('Panini error: rendering error ocurred.\n',e);
-    
+
   }
   finally {
     // This sends the modified file back into the stream
-    cb(null, file);   
+    cb(null, file);
   }
 }

--- a/lib/render.js
+++ b/lib/render.js
@@ -42,15 +42,15 @@ function render(file, enc, cb) {
     // Add any data from stream plugins
     pageData = (file.data) ? extend(pageData, file.data) : pageData;
 
-    // Add some defaults
+    // Add this page's front matter
+    pageData = extend(pageData, page.attributes);
+
+    // Finish by adding constants
     pageData = extend(pageData, {
       page: path.basename(file.path, '.html'),
       layout: layout,
       root: processRoot(file.path, this.options.root)
     });
-
-    // Finish by extending the existing data object with this page's metadata
-    pageData = extend(pageData, page.attributes);
 
     // Add special ad-hoc partials for #ifpage and #unlesspage
     this.Handlebars.registerHelper('ifpage', require('../helpers/ifPage')(pageData.page));

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "front-matter": "^2.0.5",
     "glob": "^6.0.4",
+    "deepmerge": "^0.2.10",
     "handlebars": "^3.0.0",
     "highlight.js": "^8.9.1",
     "js-yaml": "^3.5.2",


### PR DESCRIPTION
I'm not sure if this is useful.  I was having some issues when using `gulp-nav` with content/settings not coming through.  This gives the page front matter precedence.