### PR TITLE
Add data to the root level of this.data if file is named "data"

### DIFF
--- a/lib/loadData.js
+++ b/lib/loadData.js
@@ -1,7 +1,8 @@
-var fs   = require('fs');
-var glob = require('glob');
-var path = require('path');
-var yaml = require('js-yaml');
+var extend = require('deepmerge');
+var fs     = require('fs');
+var glob   = require('glob');
+var path   = require('path');
+var yaml   = require('js-yaml');
 
 /**
  * Looks for files with .json or .yml extensions within the given directory, and adds them as Handlebars variables matching the name of the file.
@@ -23,6 +24,11 @@ module.exports = function(dir) {
       data = yaml.safeLoad(fs.readFileSync(dataFiles[i]));
     }
 
-    this.data[name] = data;
+    // Adds items to the root level if the file is named "data"
+    if (name === 'data') {
+        this.data = extend(this.data, data);
+    } else {
+        this.data[name] = data;
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "front-matter": "^2.0.5",
     "glob": "^6.0.4",
+    "deepmerge": "^0.2.10",
     "handlebars": "^3.0.0",
     "highlight.js": "^8.9.1",
     "js-yaml": "^3.5.2",


### PR DESCRIPTION
Feel free to reject this if it's not useful or helpful.

We have a bunch of sites with `data.yml` and our templates expect the data at the root level (vs. `data.site_title`.