### PR TITLE
added .js module.exports support as a data source, updated tests

### DIFF
--- a/lib/loadData.js
+++ b/lib/loadData.js
@@ -8,7 +8,7 @@ var yaml  = require('js-yaml');
  * @param {string} dir - Folder to check for data files.
  */
 module.exports = function(dir) {
-  var dataFiles = utils.loadFiles(dir, '*.{json,yml}');
+  var dataFiles = utils.loadFiles(dir, '*.{js,json,yml}');
 
   for (var i in dataFiles) {
     var file = fs.readFileSync(dataFiles[i]);
@@ -17,6 +17,9 @@ module.exports = function(dir) {
     var data;
 
     if (ext === '.json') {
+      data = require(dataFiles[i])
+    }
+    else if (ext === '.js') {
       data = require(dataFiles[i])
     }
     else if (ext === '.yml') {

--- a/test/fixtures/data-js/build/index.html
+++ b/test/fixtures/data-js/build/index.html
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    eggs
+    bacon
+    toast
+    
+  </body>
+</html>

--- a/test/fixtures/data-js/data/breakfast.js
+++ b/test/fixtures/data-js/data/breakfast.js
@@ -1,0 +1,3 @@
+module.exports = {
+  items: ["eggs", "bacon", "toast"]
+}

--- a/test/fixtures/data-js/expected/index.html
+++ b/test/fixtures/data-js/expected/index.html
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    eggs
+    bacon
+    toast
+    
+  </body>
+</html>

--- a/test/fixtures/data-js/layouts/default.html
+++ b/test/fixtures/data-js/layouts/default.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    {{> body}}
+  </body>
+</html>

--- a/test/fixtures/data-js/pages/index.html
+++ b/test/fixtures/data-js/pages/index.html
@@ -1,0 +1,3 @@
+{{#each breakfast.items}}
+{{this}}
+{{/each}}

--- a/test/test.js
+++ b/test/test.js
@@ -150,6 +150,24 @@ describe('Panini', () => {
       });
   });
 
+  it('builds a page with external JS data', done => {
+    var p = new Panini({
+      root: FIXTURES + 'data-js/pages/',
+      layouts: FIXTURES + 'data-js/layouts/',
+      data: FIXTURES + 'data-js/data/'
+    });
+
+    p.refresh();
+
+    src(FIXTURES + 'data-js/pages/*')
+      .pipe(p.render())
+      .pipe(dest(FIXTURES + 'data-js/build'))
+      .on('finish', () => {
+        equal(FIXTURES + 'data-js/expected', FIXTURES + 'data-js/build');
+        done();
+      });
+  });
+
   it('builds a page with external YAML data', done => {
     var p = new Panini({
       root: FIXTURES + 'data-yaml/pages/',


### PR DESCRIPTION
I thought this may be useful in a case where you needed to populate your pages with data from an api or another http data source.