### PR TITLE
Add missing comma to the Gulp usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ var panini = require('panini');
 gulp.task('default', function() {
   gulp.src('pages/**/*.html')
     .pipe(panini({
-      root: 'pages/'
+      root: 'pages/',
       layouts: 'layouts/',
       partials: 'partials/',
       helpers: 'helpers/',


### PR DESCRIPTION
The Gulp usage is missing a comma after one of the `panini({...})` properties:

``` js
var gulp = require('gulp');
var panini = require('panini');

gulp.task('default', function() {
  gulp.src('pages/**/*.html')
    .pipe(panini({
      root: 'pages/' // <--- missing comma
      layouts: 'layouts/',
      partials: 'partials/',
      helpers: 'helpers/',
      data: 'data/'
    }))
    .pipe(gulp.dest('build'));
});
```
