### PR TITLE
Add support for subdirectory partial structure

### DIFF
--- a/lib/loadPartials.js
+++ b/lib/loadPartials.js
@@ -13,6 +13,12 @@ module.exports = function(dir) {
     var ext = path.extname(partials[i]);
     var file = fs.readFileSync(partials[i]);
     var name = path.basename(partials[i], ext);
+    var dir = path.parse(partials[i]).dir.split('/');
+
+    if (dir[dir.length-1] !== "partials") {
+      name = dir[dir.length-1] + '/' + name;
+    }
+
     this.Handlebars.registerPartial(name, file.toString() + '\n');
   }
 }


### PR DESCRIPTION
Just check if the last directory in the directory array of the file is equal to 'partials', if not prepend the folder name of the partial.
This is not recursive, one level only.
