### PR TITLE
Fixing panini.refresh() for data stored as JSON or JS

### DIFF
--- a/lib/loadData.js
+++ b/lib/loadData.js
@@ -17,10 +17,12 @@ module.exports = function(dir) {
     var data;
 
     if (ext === '.json') {
-      data = require(dataFiles[i])
+      delete require.cache[require.resolve(dataFiles[i])];
+      data = require(dataFiles[i]);
     }
     else if (ext === '.js') {
-      data = require(dataFiles[i])
+      delete require.cache[require.resolve(dataFiles[i])];
+      data = require(dataFiles[i]);
     }
     else if (ext === '.yml') {
       data = yaml.safeLoad(fs.readFileSync(dataFiles[i]));


### PR DESCRIPTION
Deleting require cache for (json or js) data file when reading them should solve the problem referred to here
- http://foundation.zurb.com/forum/posts/39727-panini-is-not-compiling-json-changes-in-refresh
