### PR TITLE
chore: update marked to 0.3.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "panini",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2511,9 +2511,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.14.tgz",
+      "integrity": "sha512-3emDbXi5/Jnv8Pff4GdrBxJhpQA2xzq/IzHGjsVvGZs7QK0wx1mg7rRy5UmP1T/Dt1RsWL8ikxIM3cHHGF/UJg=="
     },
     "merge-stream": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "handlebars": "^4.0.5",
     "highlight.js": "^8.9.1",
     "js-yaml": "^3.5.2",
-    "marked": "^0.3.6",
+    "marked": "^0.3.14",
     "nopt": "^4.0.1",
     "slash": "^1.0.0",
     "strip-bom": "2.0.0",


### PR DESCRIPTION
This also fixes two CVEs
https://nvd.nist.gov/vuln/detail/CVE-2017-17461
https://nvd.nist.gov/vuln/detail/CVE-2017-1000427