### PR TITLE
update loadPartials.js to invoke toString()

### DIFF
--- a/lib/loadPartials.js
+++ b/lib/loadPartials.js
@@ -12,7 +12,7 @@ module.exports = function(dir) {
 
   for (var i in partials) {
     var ext = path.extname(partials[i]);
-    var file = stripBom(fs.readFileSync(partials[i]));
+    var file = stripBom(fs.readFileSync(partials[i]).toString());
     var name = path.basename(partials[i], ext);
 
     this.Handlebars.registerPartial(name, file.toString());


### PR DESCRIPTION
* fix loadPartials.js to invoke toString() when accessing strip-bom


