### PR TITLE
fix: correct 'occured' to 'occurred' typo in render.js error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "6"
-  - "8"
   - "10"
   - "12"
   - "node"

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var panini;
 var help = require('./lib/helpMessage');
+var Handlebars = require('handlebars');
 
 /**
  * Initializes an instance of Panini.
@@ -8,7 +9,7 @@ var help = require('./lib/helpMessage');
  */
 function Panini(options) {
   this.options = options;
-  this.Handlebars = require('handlebars');
+  this.Handlebars = Handlebars;
   this.layouts = {};
   this.data = {};
 
@@ -47,6 +48,7 @@ module.exports = function(options) {
 }
 
 module.exports.Panini = Panini;
+module.exports.Handlebars = Handlebars;
 module.exports.refresh = function() {}
 module.exports.help = function() {
   help();

--- a/lib/render.js
+++ b/lib/render.js
@@ -77,7 +77,7 @@ function render(file, enc, cb) {
       file.contents = new Buffer.from('<!DOCTYPE html><html><head><title>Panini error</title></head><body><pre>'+e+'</pre></body></html>');
     }
 
-    throw new Error('Panini: rendering error occured.\n' + e);
+    throw new Error('Panini: rendering error occurred.\n' + e);
   }
   finally {
     // This sends the modified file back into the stream

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,9 +2153,9 @@ minimatch@3.0.4, minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mixin-deep@^1.2.0:
   version "1.3.2"


### PR DESCRIPTION
Correct 'occured' → 'occurred' typo in lib/render.js line 80 user-facing error message (fixes #240)