### PR TITLE
fix: correct 'occured' to 'occurred' typo in render.js error message

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -77,7 +77,7 @@ function render(file, enc, cb) {
       file.contents = new Buffer.from('<!DOCTYPE html><html><head><title>Panini error</title></head><body><pre>'+e+'</pre></body></html>');
     }
 
-    throw new Error('Panini: rendering error occured.\n' + e);
+    throw new Error('Panini: rendering error occurred.\n' + e);
   }
   finally {
     // This sends the modified file back into the stream


### PR DESCRIPTION
Correct 'occured' → 'occurred' typo in lib/render.js line 80 user-facing error message (fixes #240)